### PR TITLE
Update helm deploy

### DIFF
--- a/deploy_gitlab.yaml
+++ b/deploy_gitlab.yaml
@@ -4,6 +4,7 @@
     kubeconfig: "{{ kubeconfig_from_vault }}"                     # From Vault
     webext_bearer: "{{ wxt_bearer_vault }}"                       # From Vault
     colab_email: "{{ colab_user_email }}"                         # From POST
+    cert_target: "{{ cert_target | default('staging') }}"         # From POST
     subdomain: workshops.colab.ciscops.net
     helm_url: https://get.helm.sh/helm-v3.4.0-linux-amd64.tar.gz
     helm_tar: helm-v3.4.0-linux-amd64.tar.gz
@@ -66,13 +67,30 @@
         state: present
         release_name: "gitlab-{{ username }}"
         release_values:
+          image:
+            repository: registry.gitlab.com/gitlab-org/build/cng/gitlab-webservice-ce
+          workhorse:
+            image: registry.gitlab.com/gitlab-org/build/cng/gitlab-workhorse-ce
+          gitlab:
+            webservice:
+              ingress:
+                tls:
+                  enabled: true
+                  secretName: "{{ username }}-gitlab-tls"
+          registry:
+            ingress: I can get you the kubeconfig for that, }-registry-tls"
+          minio:
+            ingress:
+              tls:
+                secretName: "{{ username }}-minio-tls"
+
           global:
             hosts:
               domain: "{{ username }}.{{ subdomain }}"
-              https: false
             ingress:
               annotations:
                 kubernetes.io/ingress.class: workshops
+                cert-manager.io/issuer: "letsencrypt-{{ cert_target }}"
               configureCertmanager: false
               tls:
                 enabled: false


### PR DESCRIPTION
- add new cert_target variable.  Valid values are: prod, staging
(defaults to staging if none supplied).  This is used to select
which Letsencrypt environment is used

- Change helm deploy to set up HTTPS ingress for the gitlab